### PR TITLE
fix: revert header to older version

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,15 +7,10 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Course Materials Assistant</title>
-    <link rel="stylesheet" href="style.css?v=11">
+    <link rel="stylesheet" href="style.css?v=12">
 </head>
 <body>
     <div class="container">
-        <header>
-            <h1>Course Materials Agent</h1>
-            <p class="subtitle">Ask me anything!</p>
-        </header>
-
         <!-- Theme Toggle Button -->
         <button
             id="themeToggle"

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -94,31 +94,6 @@ body {
     padding: 0;
 }
 
-/* Header */
-header {
-    display: block;
-    padding: 1.5rem 2rem;
-    text-align: center;
-    background: var(--surface);
-    border-bottom: 1px solid var(--border-color);
-}
-
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
-
 /* Main Content Area with Sidebar */
 .main-content {
     flex: 1;
@@ -770,15 +745,7 @@ details[open] .suggested-header::before {
     .chat-main {
         order: 1;
     }
-    
-    header {
-        padding: 1rem;
-    }
-    
-    header h1 {
-        font-size: 1.5rem;
-    }
-    
+
     .chat-messages {
         padding: 1rem;
     }


### PR DESCRIPTION
Remove the new header elements while preserving the theme toggle functionality:
- Removed "Course Materials Agent" heading
- Removed "Ask me anything!" subheading
- Removed header section and border-bottom styling
- Theme toggle button remains fully functional

Fixes #5

Generated with [Claude Code](https://claude.com/claude-code)